### PR TITLE
Fix commas in data viewer

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,10 +1,10 @@
 ---
 name: Build and Push Docker Images
 
-on: push
-#  push:
-#   branches:
-#     - main
+on:
+  push:
+   branches:
+     - main
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -3,8 +3,8 @@ name: Build and Push Docker Images
 
 on:
   push:
-   branches:
-     - main
+    branches:
+      - main
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,10 +1,10 @@
 ---
 name: Build and Push Docker Images
 
-on:
-  push:
-    branches:
-      - main
+on: push
+#  push:
+#   branches:
+#     - main
 
 env:
   REGISTRY: ghcr.io

--- a/data-viewer/src/components/NexusViewer.tsx
+++ b/data-viewer/src/components/NexusViewer.tsx
@@ -11,7 +11,7 @@ export default function NexusViewer(props: {
   // Typically, we expect API_URL env var to be /plottingapi in staging and production
   const [hostName, setHostName] = useState<string>("");
   const [protocol, setProtocol] = useState<string>("http");
-  const filePath = props.filepath.split("%20").join(" ").split("%2").join(",");
+  const filePath = props.filepath.split("%20").join(" ").split("%2C").join(",");
   useEffect(() => {
     setHostName(window.location.hostname);
     setProtocol(window.location.protocol);

--- a/data-viewer/src/components/NexusViewer.tsx
+++ b/data-viewer/src/components/NexusViewer.tsx
@@ -11,6 +11,7 @@ export default function NexusViewer(props: {
   // Typically, we expect API_URL env var to be /plottingapi in staging and production
   const [hostName, setHostName] = useState<string>("");
   const [protocol, setProtocol] = useState<string>("http");
+  const filePath = props.filepath.split("%20").join(" ").split("%2").join(",");
   useEffect(() => {
     setHostName(window.location.hostname);
     setProtocol(window.location.protocol);
@@ -24,15 +25,15 @@ export default function NexusViewer(props: {
   return (
     <H5GroveProvider
       url={apiUrl}
-      filepath={props.filepath.split("%20").join(" ")}
+      filepath={filePath}
       axiosConfig={useMemo(
         () => ({
-          params: { file: props.filepath.split("%20").join(" ") },
+          params: { file: filePath },
           headers: {
             Authorization: `Bearer ${token}`,
           },
         }),
-        [props.filepath],
+        [filePath],
       )}
     >
       <App />


### PR DESCRIPTION
Closes None

## Description
Replaces URL-encoded commas with actual commas when searching for filenames.

This was an issue when some nexus filed had a comma in their filename, because of course they would have commas in their filename.
