### PR TITLE
Plotting service and dataviewer support for Sub-dirs in autoreduced folder.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           mkdir -p $CEPH_DIR/MARI/RBNumber/RB20024/autoreduced 
           touch $CEPH_DIR/MARI/RBNumber/RB20024/autoreduced/MAR29531 10.5meV_sa.nxspe
+          touch $CEPH_DIR/MARI/RBNumber/RB20024/autoreduced/MAR29531_10.5meV_sa.nxspe
 
       # We do this as the current config has production specific values (e.g. proxy and build output type)
       # and we want defaults for testing.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           cd plotting-service
           python -m pip install --upgrade pip
-          python -m pip install .
+          python -m pip install .[all]
 
       - name: Run python tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,14 +42,6 @@ jobs:
           DEV_MODE: True
         run: uvicorn plotting_service.plotting_api:app &
 
-      - name: Create archive for tests
-        env:
-          CEPH_DIR: /home/runner/work/plotting-service/plotting-service/plotting-service/test/test_ceph
-        run: |
-          mkdir -p $CEPH_DIR/MARI/RBNumber/RB20024/autoreduced 
-          touch $CEPH_DIR/MARI/RBNumber/RB20024/autoreduced/MAR29531 10.5meV_sa.nxspe
-          touch $CEPH_DIR/MARI/RBNumber/RB20024/autoreduced/MAR29531_10.5meV_sa.nxspe
-
       # We do this as the current config has production specific values (e.g. proxy and build output type)
       # and we want defaults for testing.
       - name: Remove production config

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,11 @@ jobs:
         run: uvicorn plotting_service.plotting_api:app &
 
       - name: Create archive for tests
+        env:
+          CEPH_DIR: /home/runner/work/plotting-service/plotting-service/plotting-service/test/test_ceph
         run: |
-          mkdir -p /ceph/MARI/RBNumber/RB20024/autoreduced 
-          touch /ceph/MARI/RBNumber/RB20024/autoreduced/MAR29531 10.5meV_sa.nxspe
+          mkdir -p $CEPH_DIR/MARI/RBNumber/RB20024/autoreduced 
+          touch $CEPH_DIR/ceph/MARI/RBNumber/RB20024/autoreduced/MAR29531 10.5meV_sa.nxspe
 
       # We do this as the current config has production specific values (e.g. proxy and build output type)
       # and we want defaults for testing.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,11 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install .
 
+      - name: Run python tests
+        run: |
+          cd plotting-service
+          pytest test --random-order --random-order-bucket=global --cov --cov-report=xml
+
       - name: Start backend
         env:
           CEPH_DIR: /home/runner/work/plotting-service/plotting-service/plotting-service/test/test_ceph

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,12 @@ jobs:
           CEPH_DIR: /home/runner/work/plotting-service/plotting-service/plotting-service/test/test_ceph
           DEV_MODE: True
         run: uvicorn plotting_service.plotting_api:app &
+
+      - name: Create archive for tests
+        run: |
+          mkdir -p /ceph/MARI/RBNumber/RB20024/autoreduced 
+          touch /ceph/MARI/RBNumber/RB20024/autoreduced/MAR29531 10.5meV_sa.nxspe
+
       # We do this as the current config has production specific values (e.g. proxy and build output type)
       # and we want defaults for testing.
       - name: Remove production config

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           CEPH_DIR: /home/runner/work/plotting-service/plotting-service/plotting-service/test/test_ceph
         run: |
           mkdir -p $CEPH_DIR/MARI/RBNumber/RB20024/autoreduced 
-          touch $CEPH_DIR/ceph/MARI/RBNumber/RB20024/autoreduced/MAR29531 10.5meV_sa.nxspe
+          touch $CEPH_DIR/MARI/RBNumber/RB20024/autoreduced/MAR29531 10.5meV_sa.nxspe
 
       # We do this as the current config has production specific values (e.g. proxy and build output type)
       # and we want defaults for testing.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,8 @@ jobs:
         run: |
           cd plotting-service
           python -m pip install --upgrade pip
-          python -m pip install .[all]
+          python -m pip install .
+          python -m pip install .[test]
 
       - name: Run python tests
         run: |

--- a/data-viewer/cypress/e2e/basic-loading/loading.cy.js
+++ b/data-viewer/cypress/e2e/basic-loading/loading.cy.js
@@ -16,7 +16,7 @@ describe("Basic loading tests for test nexus file", () => {
 
 describe("Test for loading nexus file with space in name", () => {
   beforeEach(() => {
-    // This URL DOES have a whitespace, but the underline makes it look like an underscore
+    // This URL DOES have a whitespace, but the underline in most IDEs makes it look like an underscore
     cy.visit(
       "http://localhost:3000/view/mari/20024/MAR29531 10.5meV_sa.nxspe",
       { failOnStatusCode: false },

--- a/data-viewer/package.json
+++ b/data-viewer/package.json
@@ -18,7 +18,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "cypress": "^13.13.1",
+    "cypress": "^13.15.0",
     "eslint": "^9",
     "eslint-config-next": "14.2.5",
     "prettier": "^3.3.3",

--- a/data-viewer/src/app/view/[instrument]/[experimentNumber]/[filename]/page.tsx
+++ b/data-viewer/src/app/view/[instrument]/[experimentNumber]/[filename]/page.tsx
@@ -1,34 +1,35 @@
-import { notFound } from "next/navigation";
 import NexusViewer from "@/components/NexusViewer";
 import "../../../../globals.css";
 import TextViewer from "@/components/TextViewer";
 
-export default function DataPage({
-  params,
-}: {
-  params: { instrument: string; experimentNumber: string; filename: string };
-}) {
-  // We expect a route of /instrument_name/experiment_number/filename
-  // This will result in a slug list of [instrument_name, experiment_number, filename]
-  const { instrument, experimentNumber, filename } = params;
-  const fileExtension = filename.split(".").pop();
-  const apiUrl = process.env.API_URL ?? "http://localhost:8000";
+  export default function DataPage({
+                                     params,
+                                   }: {
+    params: { instrument: string; experimentNumber: string; filename: string };
+  }) {
+    // We expect a route of /instrument_name/experiment_number/filename
+    // This will result in a slug list of [instrument_name, experiment_number, filename]
+    const {instrument, experimentNumber, filename} = params;
+    const fileExtension = filename.split(".").pop();
+    const apiUrl = process.env.API_URL ?? "http://localhost:8000";
 
-  return (
-    <main className="h5-container">
-      {fileExtension === "txt" ? (
-        <TextViewer
-          apiUrl={apiUrl}
-          experimentNumber={experimentNumber}
-          instrument={instrument}
-          filename={filename}
-        />
-      ) : (
-        <NexusViewer
-          filepath={`${instrument.toUpperCase()}/RBNumber/RB${experimentNumber}/autoreduced/${filename}`}
-          apiUrl={apiUrl}
-        />
-      )}
-    </main>
-  );
-}
+    return (
+        <main className="h5-container">
+          {fileExtension === "txt" ? (
+              <TextViewer
+                  apiUrl={apiUrl}
+                  experimentNumber={experimentNumber}
+                  instrument={instrument}
+                  filename={filename}
+              />
+          ) : (
+              <NexusViewer
+                  apiUrl={apiUrl}
+                  experimentNumber={experimentNumber}
+                  instrument={instrument}
+                  filename={filename}
+              />
+          )}
+        </main>
+    );
+  };

--- a/data-viewer/src/components/NexusViewer.tsx
+++ b/data-viewer/src/components/NexusViewer.tsx
@@ -37,12 +37,13 @@ export default function NexusViewer(props: {
   const [hostName, setHostName] = useState<string>("");
   const [protocol, setProtocol] = useState<string>("http");
   const [filepath, setFilePath] = useState<string>("");
+  const [token, setToken] = useState<string>("");
   useEffect(() => {
     setHostName(window.location.hostname);
     setProtocol(window.location.protocol);
+    setToken(localStorage.getItem("scigateway:token") ?? "");
   }, []);
-  const token = localStorage.getItem("scigateway:token") ?? "";
-  const groveApiUrl =
+    const groveApiUrl =
     props.apiUrl === "http://localhost:8000"
       ? props.apiUrl
       : `${protocol}//${hostName}/plottingapi`;
@@ -62,17 +63,18 @@ export default function NexusViewer(props: {
             return res.text();
       })
       .then((data) => {
-        setFilePath(data);
+          const filepath_to_use = data.replace(/"/g, "")
+          setFilePath(filepath_to_use);
       })
   }, [])
   return (
     <ErrorBoundary FallbackComponent={Fallback}>
       <H5GroveProvider
         url={groveApiUrl}
-        filepath={filepath.split("%20").join(" ")}
+        filepath={filepath}
         axiosConfig={useMemo(
           () => ({
-            params: { file: filepath.split("%20").join(" ").replace(/"/g, "") },
+            params: { file: filepath },
             headers: {
               Authorization: `Bearer ${token}`,
             },

--- a/data-viewer/src/components/NexusViewer.tsx
+++ b/data-viewer/src/components/NexusViewer.tsx
@@ -27,36 +27,57 @@ const Fallback = () => (
 );
 
 export default function NexusViewer(props: {
-  filepath: string;
+  filename: string;
+  instrument: string;
+  experimentNumber: string;
   apiUrl: string;
 }) {
   // We need to turn the env var into a full url as the h5provider can not take just the route.
   // Typically, we expect API_URL env var to be /plottingapi in staging and production
   const [hostName, setHostName] = useState<string>("");
   const [protocol, setProtocol] = useState<string>("http");
+  const [filepath, setFilePath] = useState<string>("");
   useEffect(() => {
     setHostName(window.location.hostname);
     setProtocol(window.location.protocol);
   }, []);
-  const token = localStorage.getItem("scigateway:token");
-  const apiUrl =
+  const token = localStorage.getItem("scigateway:token") ?? "";
+  const groveApiUrl =
     props.apiUrl === "http://localhost:8000"
       ? props.apiUrl
       : `${protocol}//${hostName}/plottingapi`;
+  const fileQueryUrl = `${props.apiUrl}/find_file/instrument/${props.instrument}/experiment_number/${props.experimentNumber}`
+  const fileQueryParams = `filename=${props.filename}`;
 
+  useEffect(() => {
+    const headers: { [key: string]: string } = {'Content-Type': 'application/json'};
+    if (token != "") {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+    fetch(`${fileQueryUrl}?${fileQueryParams}`, {method: 'GET', headers})
+      .then((res) => {
+            if (!res.ok) {
+              throw new Error(res.statusText);
+            }
+            return res.text();
+      })
+      .then((data) => {
+        setFilePath(data);
+      })
+  }, [])
   return (
     <ErrorBoundary FallbackComponent={Fallback}>
       <H5GroveProvider
-        url={apiUrl}
-        filepath={props.filepath.split("%20").join(" ")}
+        url={groveApiUrl}
+        filepath={filepath.split("%20").join(" ")}
         axiosConfig={useMemo(
           () => ({
-            params: { file: props.filepath.split("%20").join(" ") },
+            params: { file: filepath.split("%20").join(" ").replace(/"/g, "") },
             headers: {
               Authorization: `Bearer ${token}`,
             },
           }),
-          [props.filepath],
+          [filepath],
         )}
       >
         <App propagateErrors />

--- a/data-viewer/yarn.lock
+++ b/data-viewer/yarn.lock
@@ -14,10 +14,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cypress/request@^3.0.0":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.1.tgz#72d7d5425236a2413bd3d8bb66d02d9dc3168960"
-  integrity sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==
+"@cypress/request@^3.0.4":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.5.tgz#d893a6e68ce2636c085fcd8d7283c3186499ba63"
+  integrity sha512-v+XHd9XmWbufxF1/bTaVm2yhbxY+TB4YtWRqF2zaXBlDNMkls34KiATz0AVDLavL3iB6bQk9/7n3oY1EoLSWGA==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -25,14 +25,14 @@
     combined-stream "~1.0.6"
     extend "~3.0.2"
     forever-agent "~0.6.1"
-    form-data "~2.3.2"
-    http-signature "~1.3.6"
+    form-data "~4.0.0"
+    http-signature "~1.4.0"
     is-typedarray "~1.0.0"
     isstream "~0.1.2"
     json-stringify-safe "~5.0.1"
     mime-types "~2.1.19"
     performance-now "^2.1.0"
-    qs "6.10.4"
+    qs "6.13.0"
     safe-buffer "^5.1.2"
     tough-cookie "^4.1.3"
     tunnel-agent "^0.6.0"
@@ -1119,7 +1119,7 @@ colorette@^2.0.16:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
-combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
+combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -1167,12 +1167,12 @@ cwise-compiler@^1.0.0:
   dependencies:
     uniq "^1.0.0"
 
-cypress@^13.13.1:
-  version "13.13.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.13.1.tgz#860c1142a6e58ea412a764f0ce6ad07567721129"
-  integrity sha512-8F9UjL5MDUdgC/S5hr8CGLHbS5gGht5UOV184qc2pFny43fnkoaKxlzH/U6//zmGu/xRTaKimNfjknLT8+UDFg==
+cypress@^13.15.0:
+  version "13.15.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.15.0.tgz#5eca5387ef34b2e611cfa291967c69c2cd39381d"
+  integrity sha512-53aO7PwOfi604qzOkCSzNlWquCynLlKE/rmmpSPcziRH6LNfaDUAklQT6WJIsD8ywxlIy+uVZsnTMCCQVd2kTw==
   dependencies:
-    "@cypress/request" "^3.0.0"
+    "@cypress/request" "^3.0.4"
     "@cypress/xvfb" "^1.2.4"
     "@types/sinonjs__fake-timers" "8.1.1"
     "@types/sizzle" "^2.3.2"
@@ -2006,13 +2006,13 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
-form-data@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
-  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+form-data@~4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.1.tgz#ba1076daaaa5bfd7e99c1a6cb02aa0a5cff90d48"
+  integrity sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==
   dependencies:
     asynckit "^0.4.0"
-    combined-stream "^1.0.6"
+    combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
 fs-extra@^9.1.0:
@@ -2208,14 +2208,14 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-http-signature@~1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.3.6.tgz#cb6fbfdf86d1c974f343be94e87f7fc128662cf9"
-  integrity sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==
+http-signature@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.4.0.tgz#dee5a9ba2bf49416abc544abd6d967f6a94c8c3f"
+  integrity sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==
   dependencies:
     assert-plus "^1.0.0"
     jsprim "^2.0.2"
-    sshpk "^1.14.1"
+    sshpk "^1.18.0"
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -3118,12 +3118,12 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-qs@6.10.4:
-  version "6.10.4"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.4.tgz#6a3003755add91c0ec9eacdc5f878b034e73f9e7"
-  integrity sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==
+qs@6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.13.0.tgz#6ca3bd58439f7e245655798997787b0d88a51906"
+  integrity sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==
   dependencies:
-    side-channel "^1.0.4"
+    side-channel "^1.0.6"
 
 querystringify@^2.1.1:
   version "2.2.0"
@@ -3490,7 +3490,7 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
 
-sshpk@^1.14.1:
+sshpk@^1.18.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.18.0.tgz#1663e55cddf4d688b86a46b77f0d5fe363aba028"
   integrity sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==
@@ -3517,16 +3517,7 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3598,14 +3589,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3941,7 +3925,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -3954,15 +3938,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/plotting-service/plotting_service/plotting_api.py
+++ b/plotting-service/plotting_service/plotting_api.py
@@ -17,7 +17,7 @@ from starlette.responses import PlainTextResponse
 
 from plotting_service.auth import get_experiments_for_user, get_user_from_token
 from plotting_service.exceptions import AuthError
-from plotting_service.utils import find_file, find_experiment_number
+from plotting_service.utils import find_experiment_number, find_file
 
 stdout_handler = logging.StreamHandler(stream=sys.stdout)
 logging.basicConfig(

--- a/plotting-service/plotting_service/plotting_api.py
+++ b/plotting-service/plotting_service/plotting_api.py
@@ -82,13 +82,20 @@ async def get_text_file(instrument: str, experiment_number: int, filename: str) 
 
 @app.get("/find_file/instrument/{instrument}/experiment_number/{experiment_number}")
 async def find_file_get(instrument: str, experiment_number: int, filename: str) -> str:
+    """
+    Return the relative path to the env var CEPH_DIR that leads to the requested file if one exists.
+    :param instrument: Instrument the file belongs to.
+    :param experiment_number: Experiment number the file belongs to.
+    :param filename: Filename to find.
+    :return: The relative path to the file in the CEPH_DIR env var.
+    """
     path = find_file(CEPH_DIR, instrument, experiment_number, filename)
     if path is None:
         logger.error("Could not find the file requested.")
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST)
-    # Remove /ceph
-    if "ceph" in path.parts[1]:
-        path = Path(*path.parts[2:])
+    # Remove CEPH_DIR
+    if path.is_relative_to(CEPH_DIR):
+        path = path.relative_to(CEPH_DIR)
     return str(path)
 
 

--- a/plotting-service/plotting_service/utils.py
+++ b/plotting-service/plotting_service/utils.py
@@ -6,7 +6,6 @@ from fastapi import HTTPException
 from starlette.requests import Request
 
 
-
 def find_file(ceph_dir: str, instrument: str, experiment_number: int, filename: str) -> Path | None:
     # Run normal check
     basic_path = Path(ceph_dir) / f"{instrument.upper()}/RBNumber/RB{experiment_number}/autoreduced/{filename}"
@@ -57,6 +56,7 @@ def find_experiment_number(request: Request) -> int:
         if experiment_number is None:
             # Avoiding circular import
             from plotting_service.plotting_api import logger
+
             logger.warning(
                 f"The requested path {request.url.path} does not include an experiment number. "
                 f"Permissions cannot be checked"
@@ -69,6 +69,7 @@ def find_experiment_number(request: Request) -> int:
         else:
             # Avoiding circular import
             from plotting_service.plotting_api import logger
+
             logger.warning(
                 f"The requested nexus metadata path {request.url.path} does not include an experiment number. "
                 f"Permissions cannot be checked"

--- a/plotting-service/plotting_service/utils.py
+++ b/plotting-service/plotting_service/utils.py
@@ -1,5 +1,10 @@
+import re
 from pathlib import Path
 
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from plotting_service.plotting_api import logger
 
 def find_file(ceph_dir: str, instrument: str, experiment_number: int, filename: str) -> Path | None:
     # Run normal check
@@ -15,3 +20,34 @@ def find_file(ceph_dir: str, instrument: str, experiment_number: int, filename: 
             return found_paths[0]
 
     return None
+
+
+def find_experiment_number(request: Request) -> int:
+    experiment_number = None
+    if request.url.path.startswith("/text"):
+        experiment_number = int(request.url.path.split("/")[-1])
+    elif request.url.path.startswith("/find_file"):
+        url_parts = request.url.path.split("/")
+        last_part_seen = url_parts[-1]
+        for part in reversed(url_parts):
+            if "experiment_number" in part:
+                experiment_number = int(last_part_seen)
+            else:
+                last_part_seen = part
+        if experiment_number is None:
+            logger.warning(
+                f"The requested path {request.url.path} does not include an experiment number. "
+                f"Permissions cannot be checked"
+            )
+            raise HTTPException(400, "Request missing experiment number")
+    else:
+        match = re.search(r"%2FRB(\d+)%2F", request.url.query)
+        if match is not None:
+            experiment_number = int(match.group(1))
+        else:
+            logger.warning(
+                f"The requested nexus metadata path {request.url.path} does not include an experiment number. "
+                f"Permissions cannot be checked"
+            )
+            raise HTTPException(400, "Request missing experiment number")
+    return experiment_number

--- a/plotting-service/plotting_service/utils.py
+++ b/plotting-service/plotting_service/utils.py
@@ -6,6 +6,7 @@ from starlette.requests import Request
 
 from plotting_service.plotting_api import logger
 
+
 def find_file(ceph_dir: str, instrument: str, experiment_number: int, filename: str) -> Path | None:
     # Run normal check
     basic_path = Path(ceph_dir) / f"{instrument.upper()}/RBNumber/RB{experiment_number}/autoreduced/{filename}"

--- a/plotting-service/plotting_service/utils.py
+++ b/plotting-service/plotting_service/utils.py
@@ -42,37 +42,30 @@ def find_file(ceph_dir: str, instrument: str, experiment_number: int, filename: 
 
 
 def find_experiment_number(request: Request) -> int:
-    experiment_number = None
     if request.url.path.startswith("/text"):
-        experiment_number = int(request.url.path.split("/")[-1])
-    elif request.url.path.startswith("/find_file"):
+        return int(request.url.path.split("/")[-1])
+    if request.url.path.startswith("/find_file"):
         url_parts = request.url.path.split("/")
-        last_part_seen = url_parts[-1]
-        for part in reversed(url_parts):
-            if "experiment_number" in part:
-                experiment_number = int(last_part_seen)
-            else:
-                last_part_seen = part
-        if experiment_number is None:
-            # Avoiding circular import
+        try:
+            experiment_number_index = url_parts.index("experiment_number")
+            return int(url_parts[experiment_number_index + 1])
+        except (ValueError, IndexError):
             from plotting_service.plotting_api import logger
 
             logger.warning(
                 f"The requested path {request.url.path} does not include an experiment number. "
                 f"Permissions cannot be checked"
             )
-            raise HTTPException(400, "Request missing experiment number")
+            raise HTTPException(400, "Request missing experiment number") from None
     else:
         match = re.search(r"%2FRB(\d+)%2F", request.url.query)
         if match is not None:
-            experiment_number = int(match.group(1))
-        else:
-            # Avoiding circular import
-            from plotting_service.plotting_api import logger
+            return int(match.group(1))
+        # Avoiding circular import
+        from plotting_service.plotting_api import logger
 
-            logger.warning(
-                f"The requested nexus metadata path {request.url.path} does not include an experiment number. "
-                f"Permissions cannot be checked"
-            )
-            raise HTTPException(400, "Request missing experiment number")
-    return experiment_number
+        logger.warning(
+            f"The requested nexus metadata path {request.url.path} does not include an experiment number. "
+            f"Permissions cannot be checked"
+        )
+        raise HTTPException(400, "Request missing experiment number")

--- a/plotting-service/plotting_service/utils.py
+++ b/plotting-service/plotting_service/utils.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def find_file(ceph_dir: str, instrument: str, experiment_number: int, filename: str) -> Path | None:
+    # Run normal check
+    basic_path = Path(ceph_dir) / f"{instrument.upper()}/RBNumber/RB{experiment_number}/autoreduced/{filename}"
+    if basic_path.exists():
+        return basic_path
+
+    # Attempt to find file in autoreduced folder
+    autoreduced_folder = Path(ceph_dir) / f"{instrument.upper()}/RBNumber/RB{experiment_number}/autoreduced"
+    if autoreduced_folder.exists():
+        found_paths = list(autoreduced_folder.rglob(filename))
+        if len(found_paths) > 0 and found_paths[0].exists():
+            return found_paths[0]
+
+    return None

--- a/plotting-service/pyproject.toml
+++ b/plotting-service/pyproject.toml
@@ -27,6 +27,7 @@ formatting = [
 test = [
     "pytest==8.3.1",
     "pytest-cov==5.0.0",
+    "pytest-random-order==1.1.1",
 ]
 
 

--- a/plotting-service/test/test_utils.py
+++ b/plotting-service/test/test_utils.py
@@ -23,7 +23,15 @@ def test_find_file_in_a_dir():
         instrument_name = "FUN_INST"
         experiment_number = 1231234
         filename = "MAR1912991240_asa_dasd_123.nxspe"
-        path = Path(tmpdir) / instrument_name / "RBNumber" / f"RB{experiment_number}" / "autoreduced" / "run-123141"/ filename
+        path = (
+            Path(tmpdir)
+            / instrument_name
+            / "RBNumber"
+            / f"RB{experiment_number}"
+            / "autoreduced"
+            / "run-123141"
+            / filename
+        )
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("Hello World!")
 

--- a/plotting-service/test/test_utils.py
+++ b/plotting-service/test/test_utils.py
@@ -1,12 +1,11 @@
-from unittest import mock
-
-from fastapi import HTTPException
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest import mock
 
 import pytest
+from fastapi import HTTPException
 
-from plotting_service.utils import find_file, find_experiment_number
+from plotting_service.utils import find_experiment_number, find_file
 
 
 def test_find_most_likely_file():

--- a/plotting-service/test/test_utils.py
+++ b/plotting-service/test/test_utils.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from plotting_service.utils import find_file
+
+
+def test_find_most_likely_file():
+    with TemporaryDirectory() as tmpdir:
+        instrument_name = "FUN_INST"
+        experiment_number = 1231234
+        filename = "MAR1912991240_asa_dasd_123.nxspe"
+        path = Path(tmpdir) / instrument_name / "RBNumber" / f"RB{experiment_number}" / "autoreduced" / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("Hello World!")
+
+        found_file = find_file(tmpdir, instrument_name, experiment_number, filename)
+
+        assert found_file == path
+
+
+def test_find_file_in_a_dir():
+    with TemporaryDirectory() as tmpdir:
+        instrument_name = "FUN_INST"
+        experiment_number = 1231234
+        filename = "MAR1912991240_asa_dasd_123.nxspe"
+        path = Path(tmpdir) / instrument_name / "RBNumber" / f"RB{experiment_number}" / "autoreduced" / "run-123141"/ filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("Hello World!")
+
+        found_file = find_file(tmpdir, instrument_name, experiment_number, filename)
+
+        assert found_file == path
+
+
+def test_find_file_when_failed():
+    with TemporaryDirectory() as tmpdir:
+        instrument_name = "FUN_INST"
+        experiment_number = 1231234
+        filename = "MAR1912991240_asa_dasd_123.nxspe"
+        path = Path(tmpdir) / instrument_name / "RBNumber" / f"RB{experiment_number}" / "autoreduced" / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        found_file = find_file(tmpdir, instrument_name, experiment_number, filename)
+
+        assert found_file is None

--- a/plotting-service/test/test_utils.py
+++ b/plotting-service/test/test_utils.py
@@ -1,7 +1,12 @@
+from unittest import mock
+
+from fastapi import HTTPException
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from plotting_service.utils import find_file
+import pytest
+
+from plotting_service.utils import find_file, find_experiment_number
 
 
 def test_find_most_likely_file():
@@ -51,3 +56,39 @@ def test_find_file_when_failed():
         found_file = find_file(tmpdir, instrument_name, experiment_number, filename)
 
         assert found_file is None
+
+
+def test_find_file_does_not_allow_path_injection():
+    with TemporaryDirectory() as tmpdir:
+        instrument_name = "~/.ssh"
+        experiment_number = "id_rsa"
+        filename = "MAR1912991240_asa_dasd_123.nxspe"
+
+        with pytest.raises(HTTPException):
+            find_file(tmpdir, instrument_name, experiment_number, filename)
+
+
+def test_find_experiment_number_text():
+    request = mock.MagicMock()
+    experiment_number = 1245
+    request.url.path = f"/text/instrument/LOQ/experiment_number/{experiment_number}"
+
+    assert find_experiment_number(request) == experiment_number
+
+
+def test_find_experiment_number_find_file():
+    request = mock.MagicMock()
+    experiment_number = 1245
+    request.url.path = f"/find_file/instrument/LOQ/experiment_number/{experiment_number}"
+
+    assert find_experiment_number(request) == experiment_number
+
+
+def test_find_experiment_number_other():
+    request = mock.MagicMock()
+    experiment_number = 1245
+    path = f"/meta/?file=LOQ%2FRBNumber%2FRB{experiment_number}%2Fautoreduced%2Frun-110754%2F110754.h5&path=%2F"
+    request.url.query = path
+    request.url.path = path
+
+    assert find_experiment_number(request) == experiment_number


### PR DESCRIPTION
Closes None, part of Epic for LOQ

## Description
Changes the data viewer to first ask the plotting service to go find the file we are trying to load, then will load that file. Changes to the plotting service to add "find_file" endpoint. It is currently deployed on Staging, so is there for testing, specifically LOQ data is unviewable without it.