### PR TITLE
Add api auth to Plotting service

### DIFF
--- a/plotting-service/plotting_service/plotting_api.py
+++ b/plotting-service/plotting_service/plotting_api.py
@@ -143,7 +143,7 @@ async def find_file_generic_user_number(user_number: int, filename: str) -> str:
 
 
 @app.middleware("http")
-async def check_permissions(request: Request, call_next: typing.Callable[..., typing.Any]) -> typing.Any:
+async def check_permissions(request: Request, call_next: typing.Callable[..., typing.Any]) -> typing.Any:  # noqa: C901, PLR0911
     """
     Middleware that checks the requestee token has permissions for that experiment
     :param request: The request to check

--- a/plotting-service/plotting_service/plotting_api.py
+++ b/plotting-service/plotting_service/plotting_api.py
@@ -36,6 +36,7 @@ logger.info("Starting Plotting Service")
 
 ALLOWED_ORIGINS = ["*"]
 CEPH_DIR = os.environ.get("CEPH_DIR", "/ceph")
+API_KEY = os.environ.get("API_KEY", "")
 logger.info("Setting ceph directory to %s", CEPH_DIR)
 settings.base_dir = Path(CEPH_DIR).resolve()
 DEV_MODE = bool(os.environ.get("DEV_MODE", False))
@@ -164,6 +165,9 @@ async def check_permissions(request: Request, call_next: typing.Callable[..., ty
         raise HTTPException(HTTPStatus.UNAUTHORIZED, "Unauthenticated")
 
     token = auth_header.split(" ")[1]
+
+    if token == API_KEY and API_KEY != "":
+        return await call_next(request)
 
     try:
         user = get_user_from_token(token)

--- a/plotting-service/plotting_service/plotting_api.py
+++ b/plotting-service/plotting_service/plotting_api.py
@@ -36,7 +36,6 @@ logger.info("Starting Plotting Service")
 
 ALLOWED_ORIGINS = ["*"]
 CEPH_DIR = os.environ.get("CEPH_DIR", "/ceph")
-API_KEY = os.environ.get("API_KEY", "")
 logger.info("Setting ceph directory to %s", CEPH_DIR)
 settings.base_dir = Path(CEPH_DIR).resolve()
 DEV_MODE = bool(os.environ.get("DEV_MODE", False))
@@ -166,7 +165,8 @@ async def check_permissions(request: Request, call_next: typing.Callable[..., ty
 
     token = auth_header.split(" ")[1]
 
-    if token == API_KEY and API_KEY != "":
+    api_key = os.environ.get("API_KEY", "")
+    if token == api_key and api_key != "":
         return await call_next(request)
 
     try:

--- a/plotting-service/pyproject.toml
+++ b/plotting-service/pyproject.toml
@@ -28,6 +28,7 @@ test = [
     "pytest==8.3.1",
     "pytest-cov==5.0.0",
     "pytest-random-order==1.1.1",
+    "pytest-asyncio==0.26.0"
 ]
 
 

--- a/plotting-service/test/test_plotting_api.py
+++ b/plotting-service/test/test_plotting_api.py
@@ -1,0 +1,107 @@
+import os
+from typing import Any, Iterator
+from unittest import mock
+
+import pytest
+from fastapi.exceptions import HTTPException
+
+from plotting_service.plotting_api import check_permissions
+
+USER_TOKEN = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"  # noqa: S105
+    ".eyJ1c2VybnVtYmVyIjoxMjM0LCJyb2xlIjoidXNlciIsInVzZXJuYW1lIjoiZm9vIiwiZXhwIjoyMTUxMzA1MzA0fQ"
+    ".z7qVg2foW61rjYiKXp0Jw_cb5YkbWY-JoNG8GUVo2SY"
+)
+STAFF_TOKEN = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."  # noqa: S105
+    "eyJ1c2VybnVtYmVyIjoxMjM0LCJyb2xlIjoic3RhZmYiLCJ1c2VybmFtZSI6ImZvbyIsImV4cCI6NDg3MjQ2ODk4M30."
+    "-ktYEwdUfg5_PmUocmrAonZ6lwPJdcMoklWnVME1wLE"
+)
+
+class AwaitableNonAsyncMagicMock(mock.MagicMock):
+    def __await__(self) -> Iterator[Any]:
+        return iter([])
+
+
+@pytest.fixture(autouse=True)
+def api_key_setter():
+    os.environ["API_KEY"] = "foo"
+    yield "api_key_setter"
+    os.environ.pop("API_KEY")
+
+
+@pytest.mark.asyncio
+async def test_check_permissions_api_key():
+    request = mock.MagicMock()
+    request.headers.get("Authorization").split.return_value = [None, "foo"]
+    call_next = AwaitableNonAsyncMagicMock()
+
+    await check_permissions(request, call_next)
+
+    call_next.assert_called_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_check_permissions_api_key_failed():
+    os.environ["API_KEY"] = "ActuallyADecentAPIKey"
+    request = mock.MagicMock()
+    request.headers.get("Authorization").split.return_value = [None, "foo"]
+    call_next = AwaitableNonAsyncMagicMock()
+
+    with pytest.raises(HTTPException):
+        await check_permissions(request, call_next)
+
+    call_next.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_permissions_token_user():
+    request = mock.MagicMock()
+    request.url.path = "/data?path=/"
+    request.headers.get("Authorization").split.return_value = [None, USER_TOKEN]
+    call_next = AwaitableNonAsyncMagicMock()
+    experiment_number = str(mock.MagicMock())
+
+    with (mock.patch("plotting_service.plotting_api.find_experiment_number") as experiment_number_mock,
+          mock.patch(
+            "plotting_service.plotting_api.get_experiments_for_user") as get_experiments_for_user_mock):
+            experiment_number_mock.return_value = experiment_number
+            get_experiments_for_user_mock.return_value = [experiment_number]
+            await check_permissions(request, call_next)
+
+    call_next.assert_called_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_check_permissions_token_user_failed_no_perms():
+    request = mock.MagicMock()
+    request.headers.get("Authorization").split.return_value = [None, USER_TOKEN]
+    call_next = AwaitableNonAsyncMagicMock()
+
+    with pytest.raises(HTTPException):
+        await check_permissions(request, call_next)
+
+    call_next.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_permissions_token_staff():
+    request = mock.MagicMock()
+    request.headers.get("Authorization").split.return_value = [None, STAFF_TOKEN]
+    call_next = AwaitableNonAsyncMagicMock()
+
+    await check_permissions(request, call_next)
+
+    call_next.assert_called_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_check_permissions_token_failed_bad_token():
+    request = mock.MagicMock()
+    request.headers.get("Authorization").split.return_value = [None, "bad_token"]
+    call_next = AwaitableNonAsyncMagicMock()
+
+    with pytest.raises(HTTPException):
+        await check_permissions(request, call_next)
+
+    call_next.assert_not_called()

--- a/plotting-service/test/test_plotting_api.py
+++ b/plotting-service/test/test_plotting_api.py
@@ -1,5 +1,6 @@
 import os
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -18,6 +19,7 @@ STAFF_TOKEN = (
     "-ktYEwdUfg5_PmUocmrAonZ6lwPJdcMoklWnVME1wLE"
 )
 
+
 class AwaitableNonAsyncMagicMock(mock.MagicMock):
     def __await__(self) -> Iterator[Any]:
         return iter([])
@@ -30,7 +32,7 @@ def api_key_setter():
     os.environ.pop("API_KEY")
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_check_permissions_api_key():
     request = mock.MagicMock()
     request.headers.get("Authorization").split.return_value = [None, "foo"]
@@ -41,7 +43,7 @@ async def test_check_permissions_api_key():
     call_next.assert_called_once_with(request)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_check_permissions_api_key_failed():
     os.environ["API_KEY"] = "ActuallyADecentAPIKey"
     request = mock.MagicMock()
@@ -54,7 +56,7 @@ async def test_check_permissions_api_key_failed():
     call_next.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_check_permissions_token_user():
     request = mock.MagicMock()
     request.url.path = "/data?path=/"
@@ -62,17 +64,18 @@ async def test_check_permissions_token_user():
     call_next = AwaitableNonAsyncMagicMock()
     experiment_number = str(mock.MagicMock())
 
-    with (mock.patch("plotting_service.plotting_api.find_experiment_number") as experiment_number_mock,
-          mock.patch(
-            "plotting_service.plotting_api.get_experiments_for_user") as get_experiments_for_user_mock):
-            experiment_number_mock.return_value = experiment_number
-            get_experiments_for_user_mock.return_value = [experiment_number]
-            await check_permissions(request, call_next)
+    with (
+        mock.patch("plotting_service.plotting_api.find_experiment_number") as experiment_number_mock,
+        mock.patch("plotting_service.plotting_api.get_experiments_for_user") as get_experiments_for_user_mock,
+    ):
+        experiment_number_mock.return_value = experiment_number
+        get_experiments_for_user_mock.return_value = [experiment_number]
+        await check_permissions(request, call_next)
 
     call_next.assert_called_once_with(request)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_check_permissions_token_user_failed_no_perms():
     request = mock.MagicMock()
     request.headers.get("Authorization").split.return_value = [None, USER_TOKEN]
@@ -84,7 +87,7 @@ async def test_check_permissions_token_user_failed_no_perms():
     call_next.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_check_permissions_token_staff():
     request = mock.MagicMock()
     request.headers.get("Authorization").split.return_value = [None, STAFF_TOKEN]
@@ -95,7 +98,7 @@ async def test_check_permissions_token_staff():
     call_next.assert_called_once_with(request)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_check_permissions_token_failed_bad_token():
     request = mock.MagicMock()
     request.headers.get("Authorization").split.return_value = [None, "bad_token"]


### PR DESCRIPTION
Closes None, solves issue with production/staging where developers can't use an API key and must use a JWT

## Description
Adds the ability to use the defined plotting-service API key for auth
