### PR TITLE
Change dependency update schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       action-packages:
         patterns:
@@ -15,16 +15,16 @@ updates:
   - package-ecosystem: "pip" #
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       python-packages:
         patterns:
           - "*"
 
   - package-ecosystem: "docker"
-    directory: "/plotting-service"
+    directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       plotting-service-docker-image:
         patterns:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["python", "typescript"]
+        language: ["python"]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Updated the schedule for dependency updates from daily to weekly for GitHub Actions, pip, and Docker.

Remove typescript from codeql

Closes # <!-- Issue # here -->

## Description
